### PR TITLE
Preserving scroll position on navigation in Chrome

### DIFF
--- a/src/css/components/base.styl
+++ b/src/css/components/base.styl
@@ -13,9 +13,9 @@ html,
 body
   max-width: 100vw
   position: relative
-  overflow-x: hidden
 
 body
+  overflow-x: hidden
   min-height: 100vh
   height: 100%
   // font-family: $font-family-rubik


### PR DESCRIPTION
This seems like it works?  Chrome is fussy about this for some reason.

Addresses #9 