### PR TITLE
Adding search results page

### DIFF
--- a/build.js
+++ b/build.js
@@ -42,6 +42,7 @@ function readAllJsonFiles() {
                 'tv special',
                 'web series',
                 'video series',
+                'search',
             ].map((it) => it.toLowerCase()),
         },
     };
@@ -71,8 +72,32 @@ function readAllJsonFiles() {
             globalData.collections[tag] = globalData.collections[tag] || [];
             globalData.collections[tag].push(eleventyData);
         });
-
+        
         globalData.collections.byTitle[eleventyData.data.title] = eleventyData;
+
+        globalData.collections.search = {
+            fields: [
+                'title',
+                'description',
+                'parent',
+                'director',
+                'credit',
+                'slug',
+                'labels',
+            ]
+        };
+
+        globalData.collections.search.data = globalData.collections.all.map(function mapper(entry) {
+            const output = {};
+            for (const key of globalData.collections.search.fields) {
+                if (entry[key]) {
+                    output[key] = entry[key].toLowerCase
+                    ? entry[key].toLowerCase()
+                    : entry[key]
+                }
+            }
+            return output;
+        });
     }
 }
 

--- a/src/search.pug
+++ b/src/search.pug
@@ -1,0 +1,39 @@
+extends _includes/skeleton
+
+block vars 
+    - var title = "Nestflix";
+    - var description = "Fictional movies inside other movies";
+    - var bodyClass = "landing";
+
+block content
+    script.
+        const searchData = !{JSON.stringify(collections.search.data)};
+        const searchFields = !{JSON.stringify(collections.search.fields)};
+        function onSearchChange() {
+            const search = document.location.search.split('=')[1];
+            const entries = [];
+            searchData.forEach(function (entry) {
+                for (const field of searchFields) {
+                    if ((entry[field] || "").indexOf(search) > -1) {
+                        entries.push(entry);
+                        break;
+                    }
+                }
+            });
+            const $ul = document.querySelector('ul.card-list.thumbs');
+            entries.forEach(function (entry) {
+                const $img = document.createElement('img');
+                $img.setAttribute('alt', entry.title);
+                $img.setAttribute('src', '/img/' + entry.slug + '-thumb-640w.jpg');
+                const $a = document.createElement('a');
+                $a.setAttribute('href', '/' + entry.slug + '/');
+                $a.appendChild($img);
+                const $li = document.createElement('li');
+                $li.appendChild($a);
+                $ul.appendChild($li);
+            });
+        }
+        document.addEventListener('DOMContentLoaded', onSearchChange);
+
+    section.list.short
+        ul.card-list.thumbs


### PR DESCRIPTION
This stubs out the search results page.  The search text input doesn't do anything as of this PR; I will have to add support for it tomorrow.  The main goal here is to get the UI in front of you so you can put the visuals you want on the search results page.  Some things to think about are what the "no search results" UX looks like, etc.

You can see the page by changing the URL to `/search?search=family` or whatever other search term you want.

#15 