### PR TITLE
The Worker & Parasite Show

### DIFF
--- a/workerandparasite
+++ b/workerandparasite
@@ -1,0 +1,20 @@
+{
+  "slug": "worker-and-parasite",
+  "title": "The Worker & Parasite Show",
+  "description": "ENDUT! HOCH HECH!",
+  "parent": "The Simpsons",
+  "parentYear": "1993",
+  "rating": "G",
+  "labels": [
+    "kids"
+  ],
+  "credit": "20th Century Fox Television",
+  "altHero": "animated east europe cats and mice",
+  "layout": "movie.pug",
+  "tags": [
+    "entry",
+    "TV series",
+    "kids tv",
+    "new on nestflix"
+  ]
+}


### PR DESCRIPTION
The cartoon is 19 seconds long and opened with some Cyrillic-looking credits (сфир ет sеqонж), that account for nothing in real Cyrillic (which does not contain a backwards P in its alphabet[1]). The cartoon itself was quite unintelligible, featuring a crudely drawn cat and mouse in constructivist-like style chattering in incoherent, unsubtitled pseudo-Russian and bouncing around to the tune of depressing background music. The characters animations (except for the initial walking up of the mouse) cheaply repeat twice before the nest scene. Worker and Parasite are first seen in a factory (where a wrench and sickle are visible as well); they then move in an aisle with a crazy looking baker having a line of identical, miserable-looking peasants line up for bread, and then within a nest of squiggly lines. The cartoon concludes with an out of tune tone and with the screen reading "ENDUT! HOCH HECH!"